### PR TITLE
Add a check to ensure that video dir is not empty before using its path

### DIFF
--- a/src/Importers/Photo_Stream_Importer.php
+++ b/src/Importers/Photo_Stream_Importer.php
@@ -426,6 +426,12 @@ class Photo_Stream_Importer {
 					$comments = wpcomsp_auto_flickr_importer_get_local_file( $video_folder . '/comments.json' );
 
 					$media_path = glob( $video_folder . '/media.*' );
+
+					// If empty, log and skip.
+					if ( empty( $media_path[0] ) ) {
+						wpcomsp_auto_flickr_importer_write_log( 'No media path found for video ' . $meta['id'] );
+						continue;
+					}
 					$media_path = $media_path[0];
 
 					$categories = array();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request introduces a safeguard to the video import process in the `Photo_Stream_Importer.php` file by adding a check for missing media files. If a media file is not found, the importer will log the issue and skip the problematic video, preventing potential errors during import.

Error handling improvements:

* Added a check to ensure `media_path` exists before proceeding; if missing, a log entry is written and the video is skipped to avoid processing errors.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #2 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed video import handling to gracefully skip entries with missing media files instead of processing incomplete data. The importer now logs details about skipped entries and prevents downstream processing errors, with consistent behavior across video and photo imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->